### PR TITLE
make getTestClass non-final

### DIFF
--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -310,7 +310,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
     /**
      * Returns a {@link TestClass} object wrapping the class to be executed.
      */
-    public final TestClass getTestClass() {
+    public TestClass getTestClass() {
         return testClass;
     }
 


### PR DESCRIPTION
Allows overriding in subclasses in which the class under test is not the same as the runner class.
